### PR TITLE
fix: exercise 01 (factory pattern) - add support for unrecognized paymentProcessor

### DIFF
--- a/01_factory/funct-solution.js
+++ b/01_factory/funct-solution.js
@@ -6,13 +6,17 @@ const processPaymentWithStripe = (amount) => {
   console.log(`Processing ${amount} through Stripe`);
 };
 
+const processPaymentUnsupported = () => {
+  console.log(`Unsupported`);
+};
+
 const getPaymentProcessor = (type) => {
   const processors = {
     paypal: processPaymentWithPayPal,
     stripe: processPaymentWithStripe,
   };
 
-  return processors[type];
+  return processors[type] || processPaymentUnsupported;
 };
 
 const processOrder = (paymentType, amount) => {


### PR DESCRIPTION
When executing the first exercise for the functional solution, there is an error when calling `processOrder("unsupported", 300);`

```js
➜ node ./01_factory/funct-solution.js  
Processing 100 through PayPal
Processing 200 through Stripe
/Users/adrian/Dev/web-summer-camp-2024/websummercamp-javascriptpatterns/01_factory/funct-solution.js:21
  processPayment(amount);
  ^

TypeError: processPayment is not a function
    at processOrder (/Users/adrian/Dev/web-summer-camp-2024/websummercamp-javascriptpatterns/01_factory/funct-solution.js:21:3)
    at Object.<anonymous> (/Users/adrian/Dev/web-summer-camp-2024/websummercamp-javascriptpatterns/01_factory/funct-solution.js:26:1)
```

This PR adds a fallback function named `processPaymentUnsupported` to manage not recognized payment method